### PR TITLE
only record explicit params (don't default to 0)

### DIFF
--- a/parser_csi_test.go
+++ b/parser_csi_test.go
@@ -58,6 +58,24 @@ func TestCsiParamsIgnoreLong(t *testing.T) {
 	assert.Equal(t, expected, dispatcher.dispatched[0])
 }
 
+func TestCsiNoParams(t *testing.T) {
+	expected := testCsiSequence{
+		intermediates: []byte{},
+		ignore:        false,
+		rune:          'C',
+	}
+
+	dispatcher := &testDispatcher{}
+	parser := NewParser(dispatcher)
+
+	for _, b := range []byte("\x1b[C") {
+		parser.Advance(b)
+	}
+
+	assert.Equal(t, 1, len(dispatcher.dispatched))
+	assert.Equal(t, expected, dispatcher.dispatched[0])
+}
+
 func TestCsiParamsTrailingSemicolon(t *testing.T) {
 	expected := testCsiSequence{
 		params:        [][]uint16{{4}, {0}},


### PR DESCRIPTION
Without this change, a sequence like `\e[C` will be interpreted as `\e[0C`, which is incorrect. We need to keep track of whether a param was actually passed so that each individual sequence can determine its own default with `GetOrDefault` (`m` = 0, `C` = 1, etc).